### PR TITLE
Banner alert for new Symbiota Docs website

### DIFF
--- a/themes/dot/layouts/_default/baseof.html
+++ b/themes/dot/layouts/_default/baseof.html
@@ -17,6 +17,10 @@
     </header>
     {{ "<!-- /header -->" | safeHTML }}
     {{ end }}
+    <div class="alert alert-warning text-center m-0">
+      You are viewing the now-deprecated version of Symbiota Docs. For the new version, visit:
+      <a href="https://docs.symbiota.org/docs/about" >https://docs.symbiota.org/docs/about</a>.
+    </div>
     {{ block "main" . }}{{ end }}
     {{ partial "footer.html" . }}
   </body>


### PR DESCRIPTION
# Example:
<img width="1483" alt="Screenshot 2025-07-02 at 11 05 30 AM" src="https://github.com/user-attachments/assets/16688d6b-5c8e-42ba-8859-b093ef59fced" />

# Changes Made:

- Added an alert div below header in baseof.html with a link to a new Symbiota Docs website.